### PR TITLE
fixed issue 78

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.classpath
 /.project
 /.settings
+/bin
 
 # netbeans
 /nbproject

--- a/src/main/java/com/platymuus/bukkit/permissions/PlayerListener.java
+++ b/src/main/java/com/platymuus/bukkit/permissions/PlayerListener.java
@@ -33,13 +33,8 @@ class PlayerListener extends org.bukkit.event.player.PlayerListener {
     }
     
     @Override
-    public void onPlayerMove(PlayerMoveEvent event) {
-        plugin.setLastWorld(event.getPlayer().getName(), event.getTo().getWorld().getName());
-    }
-    
-    @Override
-    public void onPlayerTeleport(PlayerTeleportEvent event) {
-        plugin.setLastWorld(event.getPlayer().getName(), event.getTo().getWorld().getName());
+    public void onPlayerChangedWorld(PlayerChangedWorldEvent event) {
+        plugin.calculateAttachment(event.getPlayer());
     }
     
     @Override


### PR DESCRIPTION
This pull request fixes the issue reported in http://dev.bukkit.org/server-mods/permbukkit/tickets/78-permissions-do-not-immediately-update-after-a-respawn/ and others. Looking at the code, world specific permissions would only become active after a teleport or a player move but not after a respawn. I replaced the event listeners for PLAYER_MOVE and PLAYER_TELEPORT with a single listener for PLAYER_CHANGED_WORLD and cleaned up the plugin code accordingly. This should also lighten the load on busy servers a lot! :D
