### PR TITLE
Use the new separator for fetching messages.build

### DIFF
--- a/src/main/java/com/platymuus/bukkit/permissions/PlayerListener.java
+++ b/src/main/java/com/platymuus/bukkit/permissions/PlayerListener.java
@@ -81,8 +81,8 @@ class PlayerListener implements Listener {
     }
     
     private void bother(Player player) {
-        if (plugin.getConfig().getString("messages.build", "").length() > 0) {
-            String message = plugin.getConfig().getString("messages.build", "").replace('&', '\u00A7');
+        if (plugin.getConfig().getString("messages/build", "").length() > 0) {
+            String message = plugin.getConfig().getString("messages/build", "").replace('&', '\u00A7');
             player.sendMessage(message);
         }
     }


### PR DESCRIPTION
Use the new "proper" separator so that players actually get notified when they can't build.

The "messages.build" node retrieval fails when using the period. Switching to the slash works.
