### PR TITLE
added permissions.interact to allows player interaction when build is false

### DIFF
--- a/src/main/java/com/platymuus/bukkit/permissions/PlayerListener.java
+++ b/src/main/java/com/platymuus/bukkit/permissions/PlayerListener.java
@@ -48,7 +48,7 @@ class PlayerListener implements Listener {
         plugin.unregisterPlayer(event.getPlayer());
     }
     
-    // Prevent doing things in the event of permissions.build: false
+    // Prevent doing things in the event of permissions.build: false and permissions.interact: false
 
     @EventHandler
     public void onPlayerInteract(PlayerInteractEvent event) {
@@ -56,7 +56,7 @@ class PlayerListener implements Listener {
         if (event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_AIR) {
             return;
         }
-        if (!event.getPlayer().hasPermission("permissions.build")) {
+        if (!event.getPlayer().hasPermission("permissions.build")&&!event.getPlayer().hasPermission("permissions.interact")) {
             bother(event.getPlayer());
             event.setCancelled(true);
         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -44,6 +44,9 @@ permissions:
   permissions.build:
     description: Allows player to build.
     default: true
+  permissions.interact:
+    description: Allows player to interact when build is false.
+    default: false
   permissions.help:
     description: Allows viewing of usage for /permissions.
   permissions.reload:


### PR DESCRIPTION
New permission node:
permissions.interact:
    description: Allows player to interact when build is false.
    default: false
