### PR TITLE
Add finer grained permission check when adding or removing players from a group.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,23 @@
     <version>2.0</version>
     <name>PermissionsBukkit</name>
     <url>http://dev.bukkit.org/server-mods/permbukkit/</url>
+
+    <repositories>
+      <!-- Bukkit repository -->
+      <repository>
+        <id>bukkit</id>
+        <url>http://repo.bukkit.org/content/groups/public</url>
+      </repository>
+    </repositories>
+
+    <dependencies>
+       <dependency>
+         <groupId>org.bukkit</groupId>
+         <artifactId>bukkit</artifactId>
+         <version>1.3.1-R2.0</version>
+       </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>
@@ -25,13 +42,4 @@
             </resource>
         </resources>
     </build>
-    <dependencies>
-        <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>1.2.5-R3.1-SNAPSHOT</version>
-            <type>jar</type>
-            <scope>compile</scope>
-        </dependency>
-    </dependencies>
 </project>

--- a/src/main/java/com/platymuus/bukkit/permissions/PermissionsCommand.java
+++ b/src/main/java/com/platymuus/bukkit/permissions/PermissionsCommand.java
@@ -296,6 +296,7 @@ class PermissionsCommand implements CommandExecutor {
             if (split.length != 4) return usage(sender, command, "player addgroup");
             String player = split[2].toLowerCase();
             String group = split[3];
+            if (!checkPerm(sender, "player.addgroup." + group)) return true;
             
             if (plugin.getNode("users/" + player) == null) {
                 createPlayerNode(player);
@@ -318,6 +319,7 @@ class PermissionsCommand implements CommandExecutor {
             if (split.length != 4) return usage(sender, command, "player removegroup");
             String player = split[2].toLowerCase();
             String group = split[3];
+            if (!checkPerm(sender, "player.removegroup." + group)) return true;
             
             if (plugin.getNode("users/" + player) == null) {
                 createPlayerNode(player);


### PR DESCRIPTION
Now checks if a player has either player.addgroup.name or player.removegroup.name before making the change. This creates basic promote/demote functionality.
