### PR TITLE
Added separate built-in permission node for PlayerInteractEvent

### DIFF
--- a/src/main/java/com/platymuus/bukkit/permissions/PlayerListener.java
+++ b/src/main/java/com/platymuus/bukkit/permissions/PlayerListener.java
@@ -62,7 +62,7 @@ class PlayerListener implements Listener {
         if (event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_AIR) {
             return;
         }
-        if (!event.getPlayer().hasPermission("permissions.build")) {
+        if (!event.getPlayer().hasPermission("permissions.interact")) {
             bother(event.getPlayer());
             event.setCancelled(true);
         }


### PR DESCRIPTION
I've had the issue that my players weren't able to interact with signs/buttons/etc on my lobby server because of the built-in node "permissions.build". The said node cancels the PlayerInteractEvent.

I got several plugins (not my own) which are using "(ignoreCancelled = true, priority = EventPriority.HIGH)" above the PlayerInteractEvent. Here starts the mess... The event in the plugin is never been fired because of that and unfortunately I'm not allowed to edit the source (license restrictions). Tried to contact the developers but they don't seem to care that much.

The additional built-in node would make it a lot easier.
I would totally understand if this is not getting accepted because it's a "huge" change even if it's only one line of code.
