### PR TITLE
Update for 1.9 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.7.8-R0.1-SNAPSHOT</version>
+            <version>1.9-R0.1-SNAPSHOT</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>

--- a/src/main/java/com/platymuus/bukkit/permissions/PermissionsPlugin.java
+++ b/src/main/java/com/platymuus/bukkit/permissions/PermissionsPlugin.java
@@ -62,7 +62,7 @@ public final class PermissionsPlugin extends JavaPlugin {
         }
 
         // How are you gentlemen
-        int count = getServer().getOnlinePlayers().length;
+        int count = getServer().getOnlinePlayers().size();
         if (count > 0) {
             getLogger().info("Enabled successfully, " + count + " online players registered");
         } else {
@@ -155,7 +155,7 @@ public final class PermissionsPlugin extends JavaPlugin {
         }
 
         // Good day to you! I said good day!
-        int count = getServer().getOnlinePlayers().length;
+        int count = getServer().getOnlinePlayers().size();
         if (count > 0) {
             getLogger().info("Disabled successfully, " + count + " online players unregistered");
         }


### PR DESCRIPTION
Just a minor change is needed, as the deprecated array returning _getOnlinePlayers()_ has been removed. Could probably depend on 1.8 Bukkit just fine.